### PR TITLE
Add simple pMHC–TCR prediction package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
-# neoantigen
+# Neoantigen Predictor
+
+This repository provides a minimal Python implementation for training and
+predicting peptide–MHC (pMHC) and T-cell receptor (TCR) interactions.
+
+The package `pmhctcr_predictor` contains utilities to extract simple k‑mer
+features from amino‑acid sequences and train a logistic regression model.
+The provided scripts demonstrate how to train a model from a CSV file and
+predict interaction probabilities for new sequence pairs.
+
+## Requirements
+
+- Python 3.8+
+- `numpy`
+- `pandas`
+- `scikit-learn`
+- `joblib`
+
+Install the dependencies via:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Training
+
+Prepare a CSV file containing the columns `tcr_sequence`, `pmhc_sequence` and
+`label` (1 for interaction, 0 for no interaction). Then run:
+
+```bash
+python train.py train_data.csv model.joblib
+```
+
+## Prediction
+
+Given a CSV with `tcr_sequence` and `pmhc_sequence`, predict interaction
+probabilities:
+
+```bash
+python predict.py pairs.csv model.joblib predictions.csv
+```
+
+The output file will contain the original columns plus a `prediction` column
+with the predicted probability of interaction.

--- a/pmhctcr_predictor/features.py
+++ b/pmhctcr_predictor/features.py
@@ -1,0 +1,17 @@
+import itertools
+from collections import Counter
+import numpy as np
+
+# Standard amino acid alphabet
+AA_ALPHABET = "ACDEFGHIKLMNPQRSTVWY"
+
+def all_kmers(k, alphabet=AA_ALPHABET):
+    """Generate all possible k-mers for the given alphabet."""
+    return [''.join(p) for p in itertools.product(alphabet, repeat=k)]
+
+def kmer_vector(seq, k, kmers=None):
+    """Return a vector of k-mer counts for the sequence."""
+    if kmers is None:
+        kmers = all_kmers(k)
+    counts = Counter(seq[i:i+k] for i in range(len(seq) - k + 1))
+    return np.array([counts.get(kmer, 0) for kmer in kmers], dtype=float)

--- a/pmhctcr_predictor/model.py
+++ b/pmhctcr_predictor/model.py
@@ -1,0 +1,39 @@
+import pandas as pd
+import numpy as np
+from sklearn.linear_model import LogisticRegression
+from joblib import dump, load
+
+from .features import all_kmers, kmer_vector
+
+
+def build_feature_matrix(df, k=2):
+    """Create a feature matrix for a dataframe of sequences."""
+    kmers = all_kmers(k)
+    data = []
+    for _, row in df.iterrows():
+        tcr_vec = kmer_vector(row['tcr_sequence'], k, kmers)
+        pmhc_vec = kmer_vector(row['pmhc_sequence'], k, kmers)
+        data.append(np.concatenate([tcr_vec, pmhc_vec]))
+    return np.array(data)
+
+
+def train_model(train_csv, model_path, k=2):
+    """Train a logistic regression model and save it to disk."""
+    df = pd.read_csv(train_csv)
+    X = build_feature_matrix(df, k)
+    y = df['label']
+    clf = LogisticRegression(max_iter=1000)
+    clf.fit(X, y)
+    dump({'model': clf, 'k': k}, model_path)
+
+
+def predict(predict_csv, model_path, output_csv):
+    """Predict interaction probabilities for new pairs."""
+    df = pd.read_csv(predict_csv)
+    params = load(model_path)
+    clf = params['model']
+    k = params['k']
+    X = build_feature_matrix(df, k)
+    probs = clf.predict_proba(X)[:, 1]
+    df['prediction'] = probs
+    df.to_csv(output_csv, index=False)

--- a/predict.py
+++ b/predict.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+import argparse
+from pmhctcr_predictor.model import predict
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Predict pMHC-TCR interaction")
+    parser.add_argument("input_csv", help="CSV file with tcr_sequence and pmhc_sequence")
+    parser.add_argument("model_path", help="Trained model path")
+    parser.add_argument("output_csv", help="Destination for predictions")
+    args = parser.parse_args()
+    predict(args.input_csv, args.model_path, args.output_csv)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+numpy
+pandas
+scikit-learn
+joblib

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,7 @@
+from pmhctcr_predictor.features import kmer_vector, all_kmers
+
+def test_kmer_vector_length():
+    seq = "ACDE"
+    kmers = all_kmers(2)
+    vec = kmer_vector(seq, 2, kmers)
+    assert len(vec) == len(kmers)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,11 @@
+import pandas as pd
+from pmhctcr_predictor.model import build_feature_matrix
+
+def test_build_feature_matrix():
+    df = pd.DataFrame({
+        'tcr_sequence': ['ACD'],
+        'pmhc_sequence': ['EFG'],
+        'label': [1]
+    })
+    X = build_feature_matrix(df, k=1)
+    assert X.shape[0] == 1

--- a/train.py
+++ b/train.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+import argparse
+from pmhctcr_predictor.model import train_model
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Train pMHC-TCR interaction model")
+    parser.add_argument("train_csv", help="CSV file with tcr_sequence, pmhc_sequence, label")
+    parser.add_argument("model_path", help="Path to save trained model")
+    parser.add_argument("--k", type=int, default=2, help="k-mer size")
+    args = parser.parse_args()
+    train_model(args.train_csv, args.model_path, args.k)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `pmhctcr_predictor` package with feature extraction and model training
- provide CLI helpers for training and prediction
- document usage in README
- include minimal tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685ff1fa04ec83319781d9f12c462de3