### PR TITLE
Add logistic regression probability tests

### DIFF
--- a/tests/data/sample_train.csv
+++ b/tests/data/sample_train.csv
@@ -1,0 +1,5 @@
+tcr_sequence,pmhc_sequence,label
+ACDE,FGHI,1
+KLMN,PQRS,0
+QRST,VWYA,1
+CDEF,HIKL,0

--- a/tests/test_probabilities.py
+++ b/tests/test_probabilities.py
@@ -1,0 +1,16 @@
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+from pmhctcr_predictor.model import build_feature_matrix
+
+
+def test_logistic_regression_probabilities():
+    df = pd.read_csv('tests/data/sample_train.csv')
+    X = build_feature_matrix(df, k=1)
+    y = df['label']
+    clf = LogisticRegression(max_iter=1000)
+    clf.fit(X, y)
+    probs = clf.predict_proba(X)[:, 1]
+    assert probs.dtype.kind in {'f', 'd'}
+    assert probs.min() >= 0
+    assert probs.max() <= 1
+    assert all(0 <= p <= 1 for p in probs)


### PR DESCRIPTION
## Summary
- add reproducible sample training data
- add a new test to train a logistic regression model and verify prediction probabilities

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685ff47123708331b0a1a1298737585f