### PR TITLE
Add logistic regression hyperparams and metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ Prepare a CSV file containing the columns `tcr_sequence`, `pmhc_sequence` and
 python train.py train_data.csv model.joblib
 ```
 
+Extra options expose key `LogisticRegression` parameters, for example:
+
+```bash
+python train.py train_data.csv model.joblib --k 3 --C 0.5 \
+    --penalty l1 --solver liblinear --metric auc
+```
+
+The script prints the chosen training metric (accuracy by default).
+
 ## Prediction
 
 Given a CSV with `tcr_sequence` and `pmhc_sequence`, predict interaction

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,5 +1,6 @@
 import pandas as pd
-from pmhctcr_predictor.model import build_feature_matrix
+from pmhctcr_predictor.model import build_feature_matrix, train_model
+from joblib import load
 
 def test_build_feature_matrix():
     df = pd.DataFrame({
@@ -9,3 +10,52 @@ def test_build_feature_matrix():
     })
     X = build_feature_matrix(df, k=1)
     assert X.shape[0] == 1
+
+
+def test_train_model_params_and_metric(tmp_path):
+    df = pd.DataFrame({
+        "tcr_sequence": ["AAA", "CCC"],
+        "pmhc_sequence": ["DDD", "EEE"],
+        "label": [0, 1],
+    })
+    train_csv = tmp_path / "train.csv"
+    model_path = tmp_path / "model.joblib"
+    df.to_csv(train_csv, index=False)
+
+    score = train_model(
+        train_csv,
+        model_path,
+        k=1,
+        C=0.5,
+        penalty="l1",
+        solver="liblinear",
+        metric="accuracy",
+    )
+
+    params = load(model_path)
+    clf = params["model"]
+
+    assert clf.C == 0.5
+    assert clf.penalty == "l1"
+    assert clf.solver == "liblinear"
+    assert 0.0 <= score <= 1.0
+
+
+def test_train_model_auc_metric(tmp_path):
+    df = pd.DataFrame({
+        "tcr_sequence": ["AAA", "AAA", "CCC", "CCC"],
+        "pmhc_sequence": ["DDD", "EEE", "DDD", "EEE"],
+        "label": [0, 1, 0, 1],
+    })
+    train_csv = tmp_path / "train.csv"
+    model_path = tmp_path / "model.joblib"
+    df.to_csv(train_csv, index=False)
+
+    score = train_model(
+        train_csv,
+        model_path,
+        k=1,
+        metric="auc",
+    )
+
+    assert 0.0 <= score <= 1.0

--- a/train.py
+++ b/train.py
@@ -8,8 +8,23 @@ def main():
     parser.add_argument("train_csv", help="CSV file with tcr_sequence, pmhc_sequence, label")
     parser.add_argument("model_path", help="Path to save trained model")
     parser.add_argument("--k", type=int, default=2, help="k-mer size")
+    parser.add_argument("--C", type=float, default=1.0, help="Inverse regularisation strength")
+    parser.add_argument("--penalty", default="l2", help="Penalty for LogisticRegression")
+    parser.add_argument("--solver", default="lbfgs", help="Solver for LogisticRegression")
+    parser.add_argument("--max_iter", type=int, default=1000, help="Maximum iterations")
+    parser.add_argument("--metric", choices=["accuracy", "auc"], default="accuracy", help="Metric to report")
     args = parser.parse_args()
-    train_model(args.train_csv, args.model_path, args.k)
+    score = train_model(
+        args.train_csv,
+        args.model_path,
+        k=args.k,
+        C=args.C,
+        penalty=args.penalty,
+        solver=args.solver,
+        max_iter=args.max_iter,
+        metric=args.metric,
+    )
+    print(f"Training {args.metric}: {score:.4f}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- expose LogisticRegression hyperparameters in `train.py`
- compute training accuracy or AUC in `train_model`
- document new training options
- test parameter handling and metric calculation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685ff46b2e308331b3e79be05d59c38d