### PR TITLE
Add deep learning model option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ predict interaction probabilities for new sequence pairs.
 - `pandas`
 - `scikit-learn`
 - `joblib`
+- `torch` (for the optional deep learning model)
 
 Install the dependencies via:
 
@@ -29,6 +30,9 @@ Prepare a CSV file containing the columns `tcr_sequence`, `pmhc_sequence` and
 
 ```bash
 python train.py train_data.csv model.joblib
+
+# use `--method deep` to train the neural model
+# python train.py train_data.csv deep_model.pt --method deep
 ```
 
 ## Prediction
@@ -38,6 +42,9 @@ probabilities:
 
 ```bash
 python predict.py pairs.csv model.joblib predictions.csv
+
+# for the neural model use:
+# python predict.py pairs.csv deep_model.pt predictions.csv --method deep
 ```
 
 The output file will contain the original columns plus a `prediction` column

--- a/pmhctcr_predictor/deep_model.py
+++ b/pmhctcr_predictor/deep_model.py
@@ -1,0 +1,111 @@
+import pandas as pd
+import torch
+from torch.utils.data import Dataset, DataLoader
+from torch.nn.utils.rnn import pad_sequence
+import torch.nn as nn
+
+from .features import AA_ALPHABET
+
+
+_MAPPING = {aa: idx for idx, aa in enumerate(AA_ALPHABET)}
+
+def seq_to_tensor(seq: str) -> torch.Tensor:
+    """Convert an amino-acid sequence to a tensor of indices."""
+    indices = [_MAPPING[s] for s in seq if s in _MAPPING]
+    return torch.tensor(indices, dtype=torch.long)
+
+
+class SequenceDataset(Dataset):
+    """Dataset for paired sequences.
+
+    If the CSV contains a ``label`` column it will be returned as part of each
+    item.
+    """
+
+    def __init__(self, csv_file: str, labeled: bool = True):
+        self.df = pd.read_csv(csv_file)
+        self.labeled = labeled and "label" in self.df.columns
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self.df)
+
+    def __getitem__(self, idx):
+        row = self.df.iloc[idx]
+        tcr = row["tcr_sequence"]
+        pmhc = row["pmhc_sequence"]
+        if self.labeled:
+            return tcr, pmhc, float(row["label"])
+        return tcr, pmhc
+
+
+def collate_batch(batch):
+    labeled = len(batch[0]) == 3
+    if labeled:
+        tcr_seqs, pmhc_seqs, labels = zip(*batch)
+        labels = torch.tensor(labels, dtype=torch.float32)
+    else:
+        tcr_seqs, pmhc_seqs = zip(*batch)
+        labels = None
+
+    tcr_tensors = [seq_to_tensor(s) for s in tcr_seqs]
+    pmhc_tensors = [seq_to_tensor(s) for s in pmhc_seqs]
+    tcr_lengths = torch.tensor([len(t) for t in tcr_tensors])
+    pmhc_lengths = torch.tensor([len(t) for t in pmhc_tensors])
+    tcr_pad = pad_sequence(tcr_tensors, batch_first=True)
+    pmhc_pad = pad_sequence(pmhc_tensors, batch_first=True)
+
+    if labeled:
+        return tcr_pad, tcr_lengths, pmhc_pad, pmhc_lengths, labels
+    return tcr_pad, tcr_lengths, pmhc_pad, pmhc_lengths
+
+
+class SequencePairClassifier(nn.Module):
+    """Minimal neural model for sequence pairs."""
+
+    def __init__(self, alphabet: str = AA_ALPHABET, embed_dim: int = 16, hidden_dim: int = 32):
+        super().__init__()
+        self.embed = nn.Embedding(len(alphabet), embed_dim)
+        self.fc1 = nn.Linear(embed_dim * 2, hidden_dim)
+        self.act = nn.ReLU()
+        self.fc2 = nn.Linear(hidden_dim, 1)
+
+    def forward(self, tcr, tcr_len, pmhc, pmhc_len):
+        tcr_emb = self.embed(tcr).sum(dim=1) / tcr_len.unsqueeze(1)
+        pmhc_emb = self.embed(pmhc).sum(dim=1) / pmhc_len.unsqueeze(1)
+        x = torch.cat([tcr_emb, pmhc_emb], dim=1)
+        x = self.act(self.fc1(x))
+        x = self.fc2(x)
+        return x.squeeze(1)
+
+
+def train_model(train_csv: str, model_path: str, epochs: int = 5, batch_size: int = 32, lr: float = 1e-3):
+    dataset = SequenceDataset(train_csv, labeled=True)
+    loader = DataLoader(dataset, batch_size=batch_size, shuffle=True, collate_fn=collate_batch)
+    model = SequencePairClassifier()
+    criterion = nn.BCEWithLogitsLoss()
+    optimizer = torch.optim.Adam(model.parameters(), lr=lr)
+    for _ in range(epochs):
+        for tcr, tcr_len, pmhc, pmhc_len, labels in loader:
+            optimizer.zero_grad()
+            logits = model(tcr, tcr_len, pmhc, pmhc_len)
+            loss = criterion(logits, labels)
+            loss.backward()
+            optimizer.step()
+    torch.save(model.state_dict(), model_path)
+
+
+def predict(predict_csv: str, model_path: str, output_csv: str, batch_size: int = 32):
+    dataset = SequenceDataset(predict_csv, labeled=False)
+    loader = DataLoader(dataset, batch_size=batch_size, collate_fn=collate_batch)
+    model = SequencePairClassifier()
+    model.load_state_dict(torch.load(model_path, map_location="cpu"))
+    model.eval()
+    preds = []
+    with torch.no_grad():
+        for tcr, tcr_len, pmhc, pmhc_len in loader:
+            logits = model(tcr, tcr_len, pmhc, pmhc_len)
+            probs = torch.sigmoid(logits)
+            preds.extend(probs.tolist())
+    df = pd.read_csv(predict_csv)
+    df["prediction"] = preds
+    df.to_csv(output_csv, index=False)

--- a/predict.py
+++ b/predict.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import argparse
-from pmhctcr_predictor.model import predict
+from pmhctcr_predictor import model as logreg_model
+from pmhctcr_predictor import deep_model
 
 
 def main():
@@ -8,8 +9,12 @@ def main():
     parser.add_argument("input_csv", help="CSV file with tcr_sequence and pmhc_sequence")
     parser.add_argument("model_path", help="Trained model path")
     parser.add_argument("output_csv", help="Destination for predictions")
+    parser.add_argument("--method", choices=["logreg", "deep"], default="logreg", help="Model type")
     args = parser.parse_args()
-    predict(args.input_csv, args.model_path, args.output_csv)
+    if args.method == "logreg":
+        logreg_model.predict(args.input_csv, args.model_path, args.output_csv)
+    else:
+        deep_model.predict(args.input_csv, args.model_path, args.output_csv)
 
 
 if __name__ == "__main__":

--- a/tests/test_deep_model.py
+++ b/tests/test_deep_model.py
@@ -1,0 +1,31 @@
+import pandas as pd
+import torch
+
+from pmhctcr_predictor.deep_model import (
+    seq_to_tensor,
+    collate_batch,
+    SequenceDataset,
+    SequencePairClassifier,
+)
+
+
+def test_seq_to_tensor():
+    t = seq_to_tensor("AC")
+    assert t.dtype == torch.long
+    assert t.tolist() == [0, 1]
+
+
+def test_deep_model_forward(tmp_path):
+    df = pd.DataFrame({
+        "tcr_sequence": ["AC"],
+        "pmhc_sequence": ["DEF"],
+        "label": [1],
+    })
+    csv = tmp_path / "data.csv"
+    df.to_csv(csv, index=False)
+    dataset = SequenceDataset(csv)
+    batch = collate_batch([dataset[0]])
+    tcr, tcr_len, pmhc, pmhc_len, label = batch
+    model = SequencePairClassifier()
+    out = model(tcr, tcr_len, pmhc, pmhc_len)
+    assert out.shape == torch.Size([1])

--- a/train.py
+++ b/train.py
@@ -1,15 +1,20 @@
 #!/usr/bin/env python
 import argparse
-from pmhctcr_predictor.model import train_model
+from pmhctcr_predictor import model as logreg_model
+from pmhctcr_predictor import deep_model
 
 
 def main():
     parser = argparse.ArgumentParser(description="Train pMHC-TCR interaction model")
     parser.add_argument("train_csv", help="CSV file with tcr_sequence, pmhc_sequence, label")
     parser.add_argument("model_path", help="Path to save trained model")
-    parser.add_argument("--k", type=int, default=2, help="k-mer size")
+    parser.add_argument("--k", type=int, default=2, help="k-mer size for logistic regression")
+    parser.add_argument("--method", choices=["logreg", "deep"], default="logreg", help="Training method")
     args = parser.parse_args()
-    train_model(args.train_csv, args.model_path, args.k)
+    if args.method == "logreg":
+        logreg_model.train_model(args.train_csv, args.model_path, args.k)
+    else:
+        deep_model.train_model(args.train_csv, args.model_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- implement a simple PyTorch sequence pair model
- switch train.py/predict.py to accept `--method` flag
- document deep model usage in README
- add tests for deep model utilities

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685ff46150dc8331b7d8d22344c74a25