### PR TITLE
Add Python gitignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,9 @@ _book
 *.epub
 *.mobi
 *.pdf
+# Python rules:
+__pycache__/
+*.pyc
+.pytest_cache/
+*.egg-info/
+.venv/


### PR DESCRIPTION
## Summary
- extend `.gitignore` with standard Python ignores such as `__pycache__/` and `.pytest_cache/`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685ff73ac4b48331af19ba67cf02fd6e