### PR TITLE
Add pytest dependency and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,11 @@ python predict.py pairs.csv model.joblib predictions.csv
 
 The output file will contain the original columns plus a `prediction` column
 with the predicted probability of interaction.
+
+## Running Tests
+
+Install the development dependencies and run the test suite with `pytest`:
+
+```bash
+pytest
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy
 pandas
 scikit-learn
 joblib
+pytest>=8


### PR DESCRIPTION
## Summary
- add `pytest` to requirements
- document running tests with pytest in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas)*

------
https://chatgpt.com/codex/tasks/task_e_685ff73d79008331a3b68ef796f7de34