### PR TITLE
Add column validation to logistic model API

### DIFF
--- a/pmhctcr_predictor/model.py
+++ b/pmhctcr_predictor/model.py
@@ -20,6 +20,12 @@ def build_feature_matrix(df, k=2):
 def train_model(train_csv, model_path, k=2):
     """Train a logistic regression model and save it to disk."""
     df = pd.read_csv(train_csv)
+    required = {"tcr_sequence", "pmhc_sequence", "label"}
+    missing = required - set(df.columns)
+    if missing:
+        raise ValueError(
+            f"Input CSV missing columns: {', '.join(sorted(missing))}"
+        )
     X = build_feature_matrix(df, k)
     y = df['label']
     clf = LogisticRegression(max_iter=1000)
@@ -30,6 +36,12 @@ def train_model(train_csv, model_path, k=2):
 def predict(predict_csv, model_path, output_csv):
     """Predict interaction probabilities for new pairs."""
     df = pd.read_csv(predict_csv)
+    required = {"tcr_sequence", "pmhc_sequence"}
+    missing = required - set(df.columns)
+    if missing:
+        raise ValueError(
+            f"Input CSV missing columns: {', '.join(sorted(missing))}"
+        )
     params = load(model_path)
     clf = params['model']
     k = params['k']

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,5 +1,6 @@
 import pandas as pd
-from pmhctcr_predictor.model import build_feature_matrix
+import pytest
+from pmhctcr_predictor.model import build_feature_matrix, train_model, predict
 
 def test_build_feature_matrix():
     df = pd.DataFrame({
@@ -9,3 +10,22 @@ def test_build_feature_matrix():
     })
     X = build_feature_matrix(df, k=1)
     assert X.shape[0] == 1
+
+
+def test_train_model_missing_columns(tmp_path):
+    df = pd.DataFrame({"tcr_sequence": ["ACD"], "label": [1]})
+    csv = tmp_path / "train.csv"
+    df.to_csv(csv, index=False)
+    model = tmp_path / "model.joblib"
+    with pytest.raises(ValueError):
+        train_model(csv, model, k=1)
+
+
+def test_predict_missing_columns(tmp_path):
+    df = pd.DataFrame({"pmhc_sequence": ["ACD"]})
+    csv = tmp_path / "pred.csv"
+    df.to_csv(csv, index=False)
+    model = tmp_path / "model.joblib"
+    output = tmp_path / "out.csv"
+    with pytest.raises(ValueError):
+        predict(csv, model, output)


### PR DESCRIPTION
## Summary
- validate required columns in `train_model` and `predict`
- add tests for missing column errors

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas)*
- `pip install -r requirements.txt` *(fails: cannot access pypi.org)*

------
https://chatgpt.com/codex/tasks/task_e_685ff7401c6083318a015046f8232a13