### PR TITLE
Ignore Python cache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ _book
 *.epub
 *.mobi
 *.pdf
+
+# Python cache
+__pycache__/
+*.pyc


### PR DESCRIPTION
## Summary
- update `.gitignore` to ignore `__pycache__/` and Python bytecode files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685ff789fa148331826e60b14ec573f0