### PR TITLE
Add metric validation to training function

### DIFF
--- a/pmhctcr_predictor/model.py
+++ b/pmhctcr_predictor/model.py
@@ -17,14 +17,35 @@ def build_feature_matrix(df, k=2):
     return np.array(data)
 
 
-def train_model(train_csv, model_path, k=2):
-    """Train a logistic regression model and save it to disk."""
+def train_model(train_csv, model_path, k=2, metric="accuracy"):
+    """Train a logistic regression model and save it to disk.
+
+    Parameters
+    ----------
+    train_csv : str
+        Path to the training CSV file.
+    model_path : str
+        Where to save the trained model.
+    k : int, optional
+        k-mer size used for feature extraction.
+    metric : str, optional
+        Name of the evaluation metric. Only ``"accuracy"`` is supported.
+
+    Raises
+    ------
+    ValueError
+        If ``metric`` is not a supported metric name.
+    """
+
+    if metric != "accuracy":
+        raise ValueError(f"Unsupported metric: {metric}")
+
     df = pd.read_csv(train_csv)
     X = build_feature_matrix(df, k)
-    y = df['label']
+    y = df["label"]
     clf = LogisticRegression(max_iter=1000)
     clf.fit(X, y)
-    dump({'model': clf, 'k': k}, model_path)
+    dump({"model": clf, "k": k}, model_path)
 
 
 def predict(predict_csv, model_path, output_csv):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,5 +1,6 @@
 import pandas as pd
-from pmhctcr_predictor.model import build_feature_matrix
+import pytest
+from pmhctcr_predictor.model import build_feature_matrix, train_model
 
 def test_build_feature_matrix():
     df = pd.DataFrame({
@@ -9,3 +10,10 @@ def test_build_feature_matrix():
     })
     X = build_feature_matrix(df, k=1)
     assert X.shape[0] == 1
+
+
+def test_train_model_invalid_metric(tmp_path):
+    csv = "tests/data/sample_train.csv"
+    model_path = tmp_path / "model.joblib"
+    with pytest.raises(ValueError):
+        train_model(csv, model_path, metric="invalid")


### PR DESCRIPTION
## Summary
- validate the metric argument in `train_model`
- test that invalid metric names raise `ValueError`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas)*

------
https://chatgpt.com/codex/tasks/task_e_685ff78dff3483319818267d12a31bf4