### PR TITLE
Ensure torch import uses importorskip

### DIFF
--- a/tests/test_deep_model.py
+++ b/tests/test_deep_model.py
@@ -1,5 +1,6 @@
 import pandas as pd
-import torch
+import pytest
+torch = pytest.importorskip("torch")
 
 from pmhctcr_predictor.deep_model import (
     seq_to_tensor,


### PR DESCRIPTION
## Summary
- skip deep model tests if PyTorch isn't installed

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860142953508331bd27386e7ef006fd