### PR TITLE
Load deep_model only for deep method

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 import argparse
 from pmhctcr_predictor import model as logreg_model
-from pmhctcr_predictor import deep_model
 
 
 def main():
@@ -14,6 +13,7 @@ def main():
     if args.method == "logreg":
         logreg_model.predict(args.input_csv, args.model_path, args.output_csv)
     else:
+        from pmhctcr_predictor import deep_model
         deep_model.predict(args.input_csv, args.model_path, args.output_csv)
 
 

--- a/train.py
+++ b/train.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 import argparse
 from pmhctcr_predictor import model as logreg_model
-from pmhctcr_predictor import deep_model
 
 
 def main():
@@ -14,6 +13,7 @@ def main():
     if args.method == "logreg":
         logreg_model.train_model(args.train_csv, args.model_path, args.k)
     else:
+        from pmhctcr_predictor import deep_model
         deep_model.train_model(args.train_csv, args.model_path)
 
 


### PR DESCRIPTION
## Summary
- import `deep_model` lazily in `train.py` and `predict.py`

## Testing
- `python - <<'EOF'
import sys, runpy
sys.modules.pop('torch', None)
sys.argv = ['train.py', 'tests/data/sample_train.csv', 'model.joblib', '--method', 'logreg']
runpy.run_path('train.py', run_name='__main__')
print('torch' in sys.modules)
EOF`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860142744b88331b6f7e5b1c577aca5