### PR TITLE
Document PyTorch install and add requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Install the dependencies via:
 pip install -r requirements.txt
 ```
 
+Installing PyTorch may require selecting the appropriate version for your
+platform. Refer to the [PyTorch installation guide](https://pytorch.org/) if you
+encounter issues.
+
 ## Training
 
 Prepare a CSV file containing the columns `tcr_sequence`, `pmhc_sequence` and

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pandas
 scikit-learn
 joblib
 pytest>=8
+torch


### PR DESCRIPTION
## Summary
- include `torch` in requirements
- add note about choosing the right PyTorch build when installing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685ff859af388331a65d89b0f94c6e9b