### PR TITLE
Expose deep model training hyperparams

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,11 @@ python train.py train_data.csv model.joblib
 
 # use `--method deep` to train the neural model
 # python train.py train_data.csv deep_model.pt --method deep
+# optional parameters for the deep model
+# python train.py train_data.csv deep_model.pt --method deep --epochs 10 --batch-size 16 --lr 0.0005
 ```
+
+`--epochs`, `--batch-size`, and `--lr` control the number of training epochs, mini-batch size and learning rate when using the deep learning model.
 
 ## Prediction
 

--- a/train.py
+++ b/train.py
@@ -10,11 +10,20 @@ def main():
     parser.add_argument("model_path", help="Path to save trained model")
     parser.add_argument("--k", type=int, default=2, help="k-mer size for logistic regression")
     parser.add_argument("--method", choices=["logreg", "deep"], default="logreg", help="Training method")
+    parser.add_argument("--epochs", type=int, default=5, help="Number of epochs for the deep model")
+    parser.add_argument("--batch-size", type=int, default=32, help="Batch size for the deep model")
+    parser.add_argument("--lr", type=float, default=1e-3, help="Learning rate for the deep model")
     args = parser.parse_args()
     if args.method == "logreg":
         logreg_model.train_model(args.train_csv, args.model_path, args.k)
     else:
-        deep_model.train_model(args.train_csv, args.model_path)
+        deep_model.train_model(
+            args.train_csv,
+            args.model_path,
+            epochs=args.epochs,
+            batch_size=args.batch_size,
+            lr=args.lr,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend `train.py` with `--epochs`, `--batch-size` and `--lr`
- document new options in the README with an example command

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas and pmhctcr_predictor)*

------
https://chatgpt.com/codex/tasks/task_e_685ff85a723c8331b5babcadb29c0b8c