### PR TITLE
Enhance predictor with optional ESM embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Install the dependencies via:
 ```bash
 pip install -r requirements.txt
 pip install torch  # required only for --method deep
+pip install fair-esm  # required only for --method esm
 ```
 
 Installing PyTorch may require selecting the appropriate version for your
@@ -48,6 +49,8 @@ python train.py train_data.csv model.joblib
 
 # use `--method deep` to train the neural model
 # python train.py train_data.csv deep_model.pt --method deep
+# use `--method esm` to train with ESM embeddings
+# python train.py train_data.csv esm_model.joblib --method esm
 ```
 
 ## Prediction
@@ -60,6 +63,8 @@ python predict.py pairs.csv model.joblib predictions.csv
 
 # for the neural model use:
 # python predict.py pairs.csv deep_model.pt predictions.csv --method deep
+# for the ESM model use:
+# python predict.py pairs.csv esm_model.joblib predictions.csv --method esm
 ```
 
 The output file will contain the original columns plus a `prediction` column

--- a/environment.yml
+++ b/environment.yml
@@ -10,4 +10,7 @@ dependencies:
   - joblib
   - pytest>=8
   - pytorch
+  - pip
+  - pip:
+      - fair-esm
 

--- a/pmhctcr_predictor/esm_features.py
+++ b/pmhctcr_predictor/esm_features.py
@@ -1,0 +1,31 @@
+import numpy as np
+import torch
+
+try:
+    import esm
+except ImportError:  # pragma: no cover - optional dependency
+    esm = None
+
+
+class ESMEmbedder:
+    """Embed sequences using a pretrained ESM model."""
+
+    def __init__(self, model_name: str = "esm2_t6_8M_UR50D"):
+        if esm is None:
+            raise ImportError("esm package is required for ESM features")
+        self.model, self.alphabet = esm.pretrained.load_model_and_alphabet(model_name)
+        self.model.eval()
+        self.batch_converter = self.alphabet.get_batch_converter()
+
+    def embed(self, seq: str) -> np.ndarray:
+        """Return the average embedding of a sequence."""
+        _, _, tokens = self.batch_converter([("seq", seq)])
+        with torch.no_grad():
+            out = self.model(tokens, repr_layers=[-1], return_contacts=False)
+        rep = out["representations"][-1].squeeze(0)
+        return rep.mean(dim=0).cpu().numpy()
+
+    def pair_embedding(self, seq1: str, seq2: str) -> np.ndarray:
+        emb1 = self.embed(seq1)
+        emb2 = self.embed(seq2)
+        return np.concatenate([emb1, emb2])

--- a/predict.py
+++ b/predict.py
@@ -8,10 +8,17 @@ def main():
     parser.add_argument("input_csv", help="CSV file with tcr_sequence and pmhc_sequence")
     parser.add_argument("model_path", help="Trained model path")
     parser.add_argument("output_csv", help="Destination for predictions")
-    parser.add_argument("--method", choices=["logreg", "deep"], default="logreg", help="Model type")
+    parser.add_argument(
+        "--method",
+        choices=["logreg", "deep", "esm"],
+        default="logreg",
+        help="Model type",
+    )
     args = parser.parse_args()
     if args.method == "logreg":
         logreg_model.predict(args.input_csv, args.model_path, args.output_csv)
+    elif args.method == "esm":
+        logreg_model.predict_esm(args.input_csv, args.model_path, args.output_csv)
     else:
         from pmhctcr_predictor import deep_model
         deep_model.predict(args.input_csv, args.model_path, args.output_csv)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ scikit-learn
 joblib
 pytest>=8
 torch
+fair-esm  # optional, required for --method esm

--- a/tests/test_esm_features.py
+++ b/tests/test_esm_features.py
@@ -1,0 +1,12 @@
+import pytest
+
+esm = pytest.importorskip('esm')
+
+from pmhctcr_predictor.esm_features import ESMEmbedder
+
+
+def test_pair_embedding_shape():
+    embedder = ESMEmbedder()
+    vec = embedder.pair_embedding("ACD", "EFG")
+    assert vec.ndim == 1
+    assert vec.size > 0

--- a/train.py
+++ b/train.py
@@ -8,10 +8,17 @@ def main():
     parser.add_argument("train_csv", help="CSV file with tcr_sequence, pmhc_sequence, label")
     parser.add_argument("model_path", help="Path to save trained model")
     parser.add_argument("--k", type=int, default=2, help="k-mer size for logistic regression")
-    parser.add_argument("--method", choices=["logreg", "deep"], default="logreg", help="Training method")
+    parser.add_argument(
+        "--method",
+        choices=["logreg", "deep", "esm"],
+        default="logreg",
+        help="Training method",
+    )
     args = parser.parse_args()
     if args.method == "logreg":
         logreg_model.train_model(args.train_csv, args.model_path, args.k)
+    elif args.method == "esm":
+        logreg_model.train_model_esm(args.train_csv, args.model_path)
     else:
         from pmhctcr_predictor import deep_model
         deep_model.train_model(args.train_csv, args.model_path)


### PR DESCRIPTION
## Summary
- add optional ESM-based embedder
- support `esm` method in training and prediction scripts
- update docs and environment files
- add tests guarding ESM functionality

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_6862907542208331acc1b4e1de1a6eaf