### PR TITLE
Improve conda setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,14 @@ conda env create -f environment.yml
 conda activate neoantigen
 ```
 
-This installs PyTorch and the other dependencies listed above.
+This installs PyTorch and the other dependencies listed above. If you
+have custom channels defined in your `.condarc` configuration, they may
+override the channels specified in the file. In that case use the
+`--override-channels` option:
+
+```bash
+conda env create -f environment.yml --override-channels
+```
 
 Install the dependencies via:
 


### PR DESCRIPTION
## Summary
- document how to override custom `.condarc` channels
- show example with `--override-channels`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68629caf552c83318cdcf45102469847