### PR TITLE
Improve optional torch import for esm features

### DIFF
--- a/pmhctcr_predictor/esm_features.py
+++ b/pmhctcr_predictor/esm_features.py
@@ -1,5 +1,9 @@
 import numpy as np
-import torch
+
+try:
+    import torch
+except ImportError:  # pragma: no cover - optional dependency
+    torch = None
 
 try:
     import esm
@@ -13,12 +17,16 @@ class ESMEmbedder:
     def __init__(self, model_name: str = "esm2_t6_8M_UR50D"):
         if esm is None:
             raise ImportError("esm package is required for ESM features")
+        if torch is None:
+            raise ImportError("torch is required for ESM features")
         self.model, self.alphabet = esm.pretrained.load_model_and_alphabet(model_name)
         self.model.eval()
         self.batch_converter = self.alphabet.get_batch_converter()
 
     def embed(self, seq: str) -> np.ndarray:
         """Return the average embedding of a sequence."""
+        if torch is None:
+            raise ImportError("torch is required for ESM features")
         _, _, tokens = self.batch_converter([("seq", seq)])
         with torch.no_grad():
             out = self.model(tokens, repr_layers=[-1], return_contacts=False)
@@ -26,6 +34,8 @@ class ESMEmbedder:
         return rep.mean(dim=0).cpu().numpy()
 
     def pair_embedding(self, seq1: str, seq2: str) -> np.ndarray:
+        if torch is None:
+            raise ImportError("torch is required for ESM features")
         emb1 = self.embed(seq1)
         emb2 = self.embed(seq2)
         return np.concatenate([emb1, emb2])


### PR DESCRIPTION
## Summary
- conditionally import torch in `esm_features`
- fail fast when torch is missing
- protect embedding functions against missing torch

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68629c9e002483318e3142d588b34091