### PR TITLE
Handle ESM download failure in tests

### DIFF
--- a/tests/test_esm_features.py
+++ b/tests/test_esm_features.py
@@ -1,4 +1,5 @@
 import pytest
+from urllib.error import URLError
 
 esm = pytest.importorskip('esm')
 
@@ -6,7 +7,10 @@ from pmhctcr_predictor.esm_features import ESMEmbedder
 
 
 def test_pair_embedding_shape():
-    embedder = ESMEmbedder()
+    try:
+        embedder = ESMEmbedder()
+    except URLError:
+        pytest.skip("ESM weights unavailable")
     vec = embedder.pair_embedding("ACD", "EFG")
     assert vec.ndim == 1
     assert vec.size > 0


### PR DESCRIPTION
## Summary
- gracefully skip ESM feature test when weights can't be fetched

## Testing
- `pytest -q`
- `pytest tests/test_esm_features.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_6862a5dc601883318c55e750ef6eda11