### PR TITLE
Add SVM and random forest options

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,18 @@ Train a logistic regression model using k‑mer features:
 python train.py <train.csv> <model.joblib>
 ```
 
+Train a support vector machine model:
+
+```bash
+python train.py <train.csv> <svm_model.joblib> --method svm
+```
+
+Train a random forest model:
+
+```bash
+python train.py <train.csv> <rf_model.joblib> --method rf
+```
+
 Set the k‑mer size (default is 2):
 
 ```bash
@@ -96,6 +108,18 @@ For the logistic regression model:
 
 ```bash
 python predict.py <pairs.csv> <model.joblib> <predictions.csv>
+```
+
+For the SVM model:
+
+```bash
+python predict.py <pairs.csv> <svm_model.joblib> <predictions.csv> --method svm
+```
+
+For the random forest model:
+
+```bash
+python predict.py <pairs.csv> <rf_model.joblib> <predictions.csv> --method rf
 ```
 
 For the neural model:

--- a/pmhctcr_predictor/model.py
+++ b/pmhctcr_predictor/model.py
@@ -1,6 +1,8 @@
 import pandas as pd
 import numpy as np
 from sklearn.linear_model import LogisticRegression
+from sklearn.svm import SVC
+from sklearn.ensemble import RandomForestClassifier
 from joblib import dump, load
 
 from .esm_features import ESMEmbedder
@@ -33,6 +35,38 @@ def train_model(train_csv, model_path, k=2):
     clf = LogisticRegression(max_iter=1000)
     clf.fit(X, y)
     dump({'model': clf, 'k': k}, model_path)
+
+
+def train_model_svm(train_csv, model_path, k=2):
+    """Train an SVM model and save it to disk."""
+    df = pd.read_csv(train_csv)
+    required = {"tcr_sequence", "pmhc_sequence", "label"}
+    missing = required - set(df.columns)
+    if missing:
+        raise ValueError(
+            f"Input CSV missing columns: {', '.join(sorted(missing))}"
+        )
+    X = build_feature_matrix(df, k)
+    y = df["label"]
+    clf = SVC(probability=True)
+    clf.fit(X, y)
+    dump({"model": clf, "k": k}, model_path)
+
+
+def train_model_rf(train_csv, model_path, k=2, n_estimators=100):
+    """Train a random forest model and save it to disk."""
+    df = pd.read_csv(train_csv)
+    required = {"tcr_sequence", "pmhc_sequence", "label"}
+    missing = required - set(df.columns)
+    if missing:
+        raise ValueError(
+            f"Input CSV missing columns: {', '.join(sorted(missing))}"
+        )
+    X = build_feature_matrix(df, k)
+    y = df["label"]
+    clf = RandomForestClassifier(n_estimators=n_estimators)
+    clf.fit(X, y)
+    dump({"model": clf, "k": k}, model_path)
 
 
 def train_model_esm(train_csv, model_path, model_name="esm2_t6_8M_UR50D"):

--- a/predict.py
+++ b/predict.py
@@ -10,12 +10,12 @@ def main():
     parser.add_argument("output_csv", help="Destination for predictions")
     parser.add_argument(
         "--method",
-        choices=["logreg", "deep", "esm"],
+        choices=["logreg", "svm", "rf", "deep", "esm"],
         default="logreg",
         help="Model type",
     )
     args = parser.parse_args()
-    if args.method == "logreg":
+    if args.method in {"logreg", "svm", "rf"}:
         logreg_model.predict(args.input_csv, args.model_path, args.output_csv)
     elif args.method == "esm":
         logreg_model.predict_esm(args.input_csv, args.model_path, args.output_csv)

--- a/tests/test_train_predict.py
+++ b/tests/test_train_predict.py
@@ -18,3 +18,31 @@ def test_train_and_predict(tmp_path):
     df_train = pd.read_csv(train_csv)
     assert 'prediction' in df_pred.columns
     assert len(df_pred) == len(df_train)
+
+
+def test_train_and_predict_svm(tmp_path):
+    train_csv = 'tests/data/sample_train.csv'
+    model_path = tmp_path / 'svm_model.joblib'
+    output_csv = tmp_path / 'svm_pred.csv'
+
+    model.train_model_svm(train_csv, model_path, k=1)
+    model.predict(train_csv, model_path, output_csv)
+
+    df_pred = pd.read_csv(output_csv)
+    df_train = pd.read_csv(train_csv)
+    assert 'prediction' in df_pred.columns
+    assert len(df_pred) == len(df_train)
+
+
+def test_train_and_predict_rf(tmp_path):
+    train_csv = 'tests/data/sample_train.csv'
+    model_path = tmp_path / 'rf_model.joblib'
+    output_csv = tmp_path / 'rf_pred.csv'
+
+    model.train_model_rf(train_csv, model_path, k=1)
+    model.predict(train_csv, model_path, output_csv)
+
+    df_pred = pd.read_csv(output_csv)
+    df_train = pd.read_csv(train_csv)
+    assert 'prediction' in df_pred.columns
+    assert len(df_pred) == len(df_train)

--- a/train.py
+++ b/train.py
@@ -10,13 +10,17 @@ def main():
     parser.add_argument("--k", type=int, default=2, help="k-mer size for logistic regression")
     parser.add_argument(
         "--method",
-        choices=["logreg", "deep", "esm"],
+        choices=["logreg", "svm", "rf", "deep", "esm"],
         default="logreg",
         help="Training method",
     )
     args = parser.parse_args()
     if args.method == "logreg":
         logreg_model.train_model(args.train_csv, args.model_path, args.k)
+    elif args.method == "svm":
+        logreg_model.train_model_svm(args.train_csv, args.model_path, args.k)
+    elif args.method == "rf":
+        logreg_model.train_model_rf(args.train_csv, args.model_path, args.k)
     elif args.method == "esm":
         logreg_model.train_model_esm(args.train_csv, args.model_path)
     else:


### PR DESCRIPTION
## Summary
- support SVM and RandomForest classifiers
- expose new options in `train.py` and `predict.py`
- document additional model choices in README
- test SVM and random forest training/prediction

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862b82219a08331bbe7e2a87de6d9c9