### PR TITLE
Improve optional dependency docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository contains utilities for predicting interaction probabilities betw
 - `scikit-learn`
 - `joblib`
 - `pytest` (for running the tests)
-- `torch` (required only for the deep model)
+- `torch` (required for the deep and ESM models)
 - `fair-esm` (required only for the ESM model)
 
 All dependencies are listed in `requirements.txt` and `environment.yml`.
@@ -45,11 +45,20 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
-Install optional extras as needed:
+Install optional extras as needed. PyTorch is required for both the deep model
+and the ESM-based model, while the `fair-esm` package provides pretrained
+embeddings used by the ESM method.
 
 ```bash
-pip install torch      # for --method deep
-pip install fair-esm   # for --method esm
+pip install torch      # required for --method deep or esm
+pip install fair-esm   # required for --method esm
+```
+
+You can also install extras directly from this repository:
+
+```bash
+pip install -e .[deep]
+pip install -e .[esm]
 ```
 
 ### 4. Install package for development

--- a/environment.yml
+++ b/environment.yml
@@ -9,8 +9,8 @@ dependencies:
   - scikit-learn
   - joblib
   - pytest>=8
-  - pytorch
+  - pytorch        # required for deep and esm models
   - pip
   - pip:
-      - fair-esm
+      - fair-esm   # required for esm model
 

--- a/pmhctcr_predictor/deep_model.py
+++ b/pmhctcr_predictor/deep_model.py
@@ -1,3 +1,10 @@
+"""Minimal neural model for pMHC/TCR sequence pairs.
+
+This module depends on the ``torch`` package, which is not installed with the
+base requirements. Install the optional ``deep`` extra or manually install
+PyTorch if you want to train or run the deep learning model.
+"""
+
 import pandas as pd
 import torch
 from torch.utils.data import Dataset, DataLoader

--- a/pmhctcr_predictor/esm_features.py
+++ b/pmhctcr_predictor/esm_features.py
@@ -1,3 +1,10 @@
+"""Utilities for embedding sequences using pretrained ESM models.
+
+The functions in this module require both ``torch`` and ``fair-esm`` to be
+installed. These heavy dependencies are optional and only needed when running
+the ESM-based model.
+"""
+
 import numpy as np
 
 try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ pandas
 scikit-learn
 joblib
 pytest>=8
-torch
+torch     # optional, required for --method deep or esm
 fair-esm  # optional, required for --method esm


### PR DESCRIPTION
## Summary
- clarify requirement bullet for torch and fair-esm
- add instructions on installing extras for deep and ESM models
- document optional dependencies in modules
- comment optional packages in config files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6863328878b48331a096014f111a953d