### PR TITLE
Enforce k>0 for feature generation

### DIFF
--- a/pmhctcr_predictor/features.py
+++ b/pmhctcr_predictor/features.py
@@ -7,10 +7,14 @@ AA_ALPHABET = "ACDEFGHIKLMNPQRSTVWY"
 
 def all_kmers(k, alphabet=AA_ALPHABET):
     """Generate all possible k-mers for the given alphabet."""
+    if not isinstance(k, int) or k <= 0:
+        raise ValueError("k must be a positive integer")
     return [''.join(p) for p in itertools.product(alphabet, repeat=k)]
 
 def kmer_vector(seq, k, kmers=None):
     """Return a vector of k-mer counts for the sequence."""
+    if not isinstance(k, int) or k <= 0:
+        raise ValueError("k must be a positive integer")
     if kmers is None:
         kmers = all_kmers(k)
     counts = Counter(seq[i:i+k] for i in range(len(seq) - k + 1))

--- a/pmhctcr_predictor/model.py
+++ b/pmhctcr_predictor/model.py
@@ -12,6 +12,8 @@ from .features import all_kmers, kmer_vector
 
 def build_feature_matrix(df, k=2):
     """Create a feature matrix for a dataframe of sequences."""
+    if not isinstance(k, int) or k <= 0:
+        raise ValueError("k must be a positive integer")
     kmers = all_kmers(k)
     data = []
     for _, row in df.iterrows():

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,3 +1,4 @@
+import pytest
 from pmhctcr_predictor.features import kmer_vector, all_kmers
 
 def test_kmer_vector_length():
@@ -5,3 +6,11 @@ def test_kmer_vector_length():
     kmers = all_kmers(2)
     vec = kmer_vector(seq, 2, kmers)
     assert len(vec) == len(kmers)
+
+
+def test_invalid_k_raises():
+    seq = "ACDE"
+    with pytest.raises(ValueError):
+        all_kmers(0)
+    with pytest.raises(ValueError):
+        kmer_vector(seq, 0)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -12,6 +12,16 @@ def test_build_feature_matrix():
     assert X.shape[0] == 1
 
 
+def test_build_feature_matrix_invalid_k():
+    df = pd.DataFrame({
+        "tcr_sequence": ["ACD"],
+        "pmhc_sequence": ["EFG"],
+        "label": [1],
+    })
+    with pytest.raises(ValueError):
+        build_feature_matrix(df, k=0)
+
+
 def test_train_model_missing_columns(tmp_path):
     df = pd.DataFrame({"tcr_sequence": ["ACD"], "label": [1]})
     csv = tmp_path / "train.csv"
@@ -19,6 +29,19 @@ def test_train_model_missing_columns(tmp_path):
     model = tmp_path / "model.joblib"
     with pytest.raises(ValueError):
         train_model(csv, model, k=1)
+
+
+def test_train_model_invalid_k(tmp_path):
+    df = pd.DataFrame({
+        "tcr_sequence": ["ACD"],
+        "pmhc_sequence": ["EFG"],
+        "label": [1],
+    })
+    csv = tmp_path / "train.csv"
+    df.to_csv(csv, index=False)
+    model_path = tmp_path / "model.joblib"
+    with pytest.raises(ValueError):
+        train_model(csv, model_path, k=0)
 
 
 def test_predict_missing_columns(tmp_path):


### PR DESCRIPTION
## Summary
- validate that k is a positive integer in feature helpers and model building
- raise ValueError when k <= 0 in build_feature_matrix
- add unit tests covering these checks

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686338639f2c83318e5412dba851b872